### PR TITLE
rename-badly-named-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [v1.1.1](https://github.com/TelescopeSt/Telescope/compare/v1.1.0...v1.1.1) (2018-10-30)
+
+## Enhancement
+
+* Rename `connectIfNotFollowingProperty:` into `#connectIfNotAlreadyFollowingProperty:`. ([84a32a](https://github.com/TelescopeSt/Telescope/commit/84a32a68f0f58af387092501fc70dace62837cdd))
+
 # [v1.1.0](https://github.com/TelescopeSt/Telescope/compare/v1.0.1...v1.1.0) (2018-10-29)
 
 ## Features

--- a/src/Telescope-Core/TLAbstractNode.class.st
+++ b/src/Telescope-Core/TLAbstractNode.class.st
@@ -80,7 +80,7 @@ TLAbstractNode >> connectFromNode: aTLNode [
 ]
 
 { #category : #connect }
-TLAbstractNode >> connectIfNotFollowingProperty: aBlockOrSymbol context: aTLEntitiesGroup [
+TLAbstractNode >> connectIfNotAlreadyFollowingProperty: aBlockOrSymbol context: aTLEntitiesGroup [
 	| target |
 	target := aBlockOrSymbol value: self entity.
 	^ (target isCollection and: [ target isString not ])
@@ -89,6 +89,16 @@ TLAbstractNode >> connectIfNotFollowingProperty: aBlockOrSymbol context: aTLEnti
 			[ {(self connectIfNotTo: (aTLEntitiesGroup nodeForEntity: target))} ]
 				on: NotFound
 				do: [ #() ] ]
+]
+
+{ #category : #connect }
+TLAbstractNode >> connectIfNotFollowingProperty: aBlockOrSymbol context: aTLEntitiesGroup [
+	self
+		deprecated: 'The name of this method is not repersentative of what it does, please use #connectIfNotAlreadyFollowingProperty:context: instead.'
+		transformWith:
+			'`@receiver connectIfNotFollowingProperty: `@statements1 context: `@statements2'
+				-> '`@receiver connectIfNotAlreadyFollowingProperty: `@statements1 context: `@statements2'.
+	^ self connectIfNotAlreadyFollowingProperty: aBlockOrSymbol context: aTLEntitiesGroup
 ]
 
 { #category : #connect }

--- a/src/Telescope-Core/TTLConnectable.trait.st
+++ b/src/Telescope-Core/TTLConnectable.trait.st
@@ -28,13 +28,31 @@ TTLConnectable >> connectFrom: aTLEntity entity: anObject [
 ]
 
 { #category : #connect }
+TTLConnectable >> connectIfNotAlreadyFollowingProperty: aBlockOrSymbol [
+	^ self connectIfNotAlreadyFollowingProperty: aBlockOrSymbol context: self
+]
+
+{ #category : #connect }
+TTLConnectable >> connectIfNotAlreadyFollowingProperty: aBlockOrSymbol context: aTLEntitiesGroup [
+	^ self flatCollect: [ :tlEntity | tlEntity connectIfNotFollowingProperty: aBlockOrSymbol context: aTLEntitiesGroup ]
+]
+
+{ #category : #connect }
 TTLConnectable >> connectIfNotFollowingProperty: aBlockOrSymbol [
-	^ self connectIfNotFollowingProperty: aBlockOrSymbol context: self
+	self
+		deprecated: 'The name of this method is not repersentative of what it does, please use #connectIfNotAlreadyFollowingProperty: instead.'
+		transformWith: '`@receiver connectIfNotFollowingProperty: `@statements1' -> '`@receiver connectIfNotAlreadyFollowingProperty: `@statements1'.
+	^ self connectIfNotAlreadyFollowingProperty: aBlockOrSymbol
 ]
 
 { #category : #connect }
 TTLConnectable >> connectIfNotFollowingProperty: aBlockOrSymbol context: aTLEntitiesGroup [
-	^ self flatCollect: [ :tlEntity | tlEntity connectIfNotFollowingProperty: aBlockOrSymbol context: aTLEntitiesGroup ]
+	self
+		deprecated: 'The name of this method is not repersentative of what it does, please use #connectIfNotAlreadyFollowingProperty:context: instead.'
+		transformWith:
+			'`@receiver connectIfNotFollowingProperty: `@statements1 context: `@statements2'
+				-> '`@receiver connectIfNotAlreadyFollowingProperty: `@statements1 context: `@statements2'.
+	^ self connectIfNotAlreadyFollowingProperty: aBlockOrSymbol context: aTLEntitiesGroup
 ]
 
 { #category : #connect }


### PR DESCRIPTION
Rename badly named method. 

Fixes #74