### PR TITLE
81-TLDemo-classexampleAllShapes-should-not-depend-on-Cytoscape

### DIFF
--- a/src/Telescope-Core/TLConnector.class.st
+++ b/src/Telescope-Core/TLConnector.class.st
@@ -509,7 +509,7 @@ TLConnector >> menuInteractionByDrawable: anObject [
 
 { #category : #accessing }
 TLConnector >> nodesShapesAvailableForConnector [
-	"I should return all TL shape that can apply on a node for this connector."
+	"I should return all Telescope shapes that can apply on a node for this connector."
 	
 	^ self subclassResponsibility
 ]

--- a/src/Telescope-Core/TLConnector.class.st
+++ b/src/Telescope-Core/TLConnector.class.st
@@ -507,6 +507,13 @@ TLConnector >> menuInteractionByDrawable: anObject [
 	menuInteractionByDrawable := anObject
 ]
 
+{ #category : #accessing }
+TLConnector >> nodesShapesAvailableForConnector [
+	"I should return all TL shape that can apply on a node for this connector."
+	
+	^ self subclassResponsibility
+]
+
 { #category : #opening }
 TLConnector >> open: aTLVisualization inWindowSized: aDimension titled: aString [ 
 	self subclassResponsibility 

--- a/src/Telescope-Demo/TLDemos.class.st
+++ b/src/Telescope-Demo/TLDemos.class.st
@@ -44,13 +44,7 @@ TLDemos class >> exampleAllShapes [
 		nodeLabel: #displayName.
 	visualization layout: TLCircularLayout.
 	visualization legend nodeShapeDescription: #displayName forNodes: [ visualization obtain recursively nodes ].
-	TLSimpleShape
-		allSubclassesDo: [ :aSubclass | 
-			self flag: #todo.	"Remove dependency to Cytoscape. Maybe implement TLShape class>>#isForNode and TLShape class>>#isForConnection?"
-			[ aSubclass forCytoscapeNode.
-			(visualization addNodeFromEntity: aSubclass) styleSheet shape: aSubclass ]
-				on: TLNotSupportedFunctionalityException
-				do: [  ] ].
+	visualization generator nodesShapesAvailableForConnector do: [ :aSubclass | (visualization addNodeFromEntity: aSubclass) styleSheet shape: aSubclass ].
 	^ visualization
 ]
 


### PR DESCRIPTION
Remove dependency to Cytoscape in TLDemos.

Fixes #81