### PR TITLE
97-Telescope-should-warn-the-user-in-case-the-only-available-connector-is-the-Test-connector

### DIFF
--- a/src/Telescope-Core-Tests/TLConnectorTest.class.st
+++ b/src/Telescope-Core-Tests/TLConnectorTest.class.st
@@ -11,6 +11,11 @@ Class {
 	#category : #'Telescope-Core-Tests'
 }
 
+{ #category : #testing }
+TLConnectorTest class >> isRealConnector [
+	^ false
+]
+
 { #category : #accessing }
 TLConnectorTest class >> priority [
 	^ 1

--- a/src/Telescope-Core-Tests/TLVisualizationTests.class.st
+++ b/src/Telescope-Core-Tests/TLVisualizationTests.class.st
@@ -19,11 +19,6 @@ TLVisualizationTests >> testChildrenNodeInVisu [
 ]
 
 { #category : #tests }
-TLVisualizationTests >> testGeneratorNotNil [
-	self assert: visualization generator notNil
-]
-
-{ #category : #tests }
 TLVisualizationTests >> testRemovedNodeHasNoConnection [
 	| node |
 	visualization > #one addNodesFromEntities: (1 to: 4).

--- a/src/Telescope-Core/TLConnector.class.st
+++ b/src/Telescope-Core/TLConnector.class.st
@@ -46,7 +46,14 @@ Class {
 
 { #category : #accessing }
 TLConnector class >> default [
-	^ self allSubclasses detectMax: #priority
+	^ (self allSubclasses select: #isRealConnector)
+		ifEmpty: [ TLNoConnectorException signal ]
+		ifNotEmpty: [ :connectors | connectors detectMax: #priority ]
+]
+
+{ #category : #testing }
+TLConnector class >> isRealConnector [
+	^ self ~= TLConnector
 ]
 
 { #category : #accessing }

--- a/src/Telescope-Core/TLNoConnectorException.class.st
+++ b/src/Telescope-Core/TLNoConnectorException.class.st
@@ -1,0 +1,17 @@
+"
+Description
+--------------------
+
+I am a Telescope error raised in case we try to get the connector for a visualization but there is none present in the image.
+"
+Class {
+	#name : #TLNoConnectorException,
+	#superclass : #Error,
+	#category : #'Telescope-Core-Exceptions'
+}
+
+{ #category : #initialization }
+TLNoConnectorException >> initialize [
+	super initialize.
+	self messageText: 'No valid connector present in the image.'
+]

--- a/src/Telescope-Core/TLViewConnector.class.st
+++ b/src/Telescope-Core/TLViewConnector.class.st
@@ -10,6 +10,11 @@ Class {
 	#category : #'Telescope-Core-Connector'
 }
 
+{ #category : #testing }
+TLViewConnector class >> isRealConnector [
+	^ self ~= TLViewConnector
+]
+
 { #category : #accessing }
 TLViewConnector class >> priority [
 	^ -100

--- a/src/Telescope-Core/TLVisualization.class.st
+++ b/src/Telescope-Core/TLVisualization.class.st
@@ -143,7 +143,15 @@ TLVisualization >> legend: aTLLegend [
 
 { #category : #'instance creation' }
 TLVisualization >> open [
-	self generator open: self inWindowSized: self openingDimension titled: self title.
+	[ self generator open: self inWindowSized: self openingDimension titled: self title ]
+		on: TLNoConnectorException
+		do: [ UIManager default
+				alert:
+					'Telescope is an engine for efficiently creating meaningful visualizations but Telescope is not a project to render visualizations by itself. 
+			
+Telescope allows one to create a model of visualization and then to render them via a connector to a visualization framework.
+You are currently missing a connector to render the visualization. You can find more informations at: https://github.com/TelescopeSt/Telescope'
+				title: 'No connector present in the image' ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
When Telescope has no connector, provide an explanation to the user.

Fixes #97