### PR TITLE
127-Move-layout-application-in-abstract-connector

### DIFF
--- a/src/Telescope-Core/TLConnector.class.st
+++ b/src/Telescope-Core/TLConnector.class.st
@@ -88,7 +88,7 @@ TLConnector >> addElementNodeInView: element [
 
 { #category : #layout }
 TLConnector >> applyLayoutOf: aTLGroup on: group [
-	self subclassResponsibility
+	aTLGroup layout on: group
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
Move layout application to Telescope.

Fixes #127