### PR TITLE
88-Use-a-DynamicVariable-to-define-the-default-connector-to-use

### DIFF
--- a/src/Telescope-Core-Tests/TLTelescopeTest.class.st
+++ b/src/Telescope-Core-Tests/TLTelescopeTest.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #TLTelescopeTest,
-	#superclass : #TestCase,
+	#superclass : #TLWithTestConnectorTest,
 	#category : #'Telescope-Core-Tests-Model'
 }
 

--- a/src/Telescope-Core-Tests/TLTestConnector.class.st
+++ b/src/Telescope-Core-Tests/TLTestConnector.class.st
@@ -56,6 +56,13 @@ TLTestConnector >> childrenByParent: anObject [
 	childrenByParent := anObject
 ]
 
+{ #category : #accessing }
+TLTestConnector >> connectionHeadShapesAvailableForConnector [
+	"I should return all Telescope shapes that can apply on a connection heads for this connector."
+
+	^ TLSimpleShape allSubclasses
+]
+
 { #category : #'generation - connection' }
 TLTestConnector >> createElementConnection: aTLConnection From: aTLSimpleNode to: aTargetTLSimpleNode [
 	^ aTLConnection -> (aTLSimpleNode -> aTargetTLSimpleNode)
@@ -96,6 +103,11 @@ TLTestConnector >> initialize [
 	super initialize.
 	view := OrderedCollection new.
 	childrenByParent := Dictionary new.
+]
+
+{ #category : #accessing }
+TLTestConnector >> nodesShapesAvailableForConnector [
+	^ TLSimpleShape allSubclasses
 ]
 
 { #category : #placing }

--- a/src/Telescope-Core-Tests/TLWithTestConnectorTest.class.st
+++ b/src/Telescope-Core-Tests/TLWithTestConnectorTest.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #TLWithTestConnectorTest,
+	#superclass : #TestCase,
+	#category : #'Telescope-Core-Tests-Model'
+}
+
+{ #category : #testing }
+TLWithTestConnectorTest class >> isAbstract [
+	^ self = TLWithTestConnectorTest
+]
+
+{ #category : #private }
+TLWithTestConnectorTest >> performTest [
+	TLCurrentConnector value: TLTestConnector during: [ super performTest ]
+]

--- a/src/Telescope-Core/TLConnector.class.st
+++ b/src/Telescope-Core/TLConnector.class.st
@@ -46,9 +46,8 @@ Class {
 
 { #category : #accessing }
 TLConnector class >> default [
-	^ (self allSubclasses select: #isRealConnector)
-		ifEmpty: [ TLNoConnectorException signal ]
-		ifNotEmpty: [ :connectors | connectors detectMax: #priority ]
+	self deprecated: 'Use TLCurrentConnector instead' transformWith: '`@receiver default' -> 'TLCurrentConnector value'.
+	^ TLCurrentConnector value
 ]
 
 { #category : #testing }

--- a/src/Telescope-Core/TLCurrentConnector.class.st
+++ b/src/Telescope-Core/TLCurrentConnector.class.st
@@ -1,0 +1,25 @@
+"
+Description
+--------------------
+
+I am a dynamic variable defining the current `Connector` to use to render a visualization.
+
+Examples
+--------------------
+
+	TLCurrentConnector value: TLCytoscapeConnector during: [ 
+		visualization open
+	]
+"
+Class {
+	#name : #TLCurrentConnector,
+	#superclass : #DynamicVariable,
+	#category : #'Telescope-Core-Connector'
+}
+
+{ #category : #accessing }
+TLCurrentConnector >> default [
+	^ (TLConnector allSubclasses select: #isRealConnector)
+		ifEmpty: [ TLNoConnectorException signal ]
+		ifNotEmpty: [ :connectors | connectors detectMax: #priority ]
+]

--- a/src/Telescope-Core/TLVisualization.class.st
+++ b/src/Telescope-Core/TLVisualization.class.st
@@ -65,7 +65,7 @@ TLVisualization >> defaultBackgroundColor [
 
 { #category : #default }
 TLVisualization >> defaultConnector [
-	^ TLConnector default new
+	^ TLCurrentConnector value new
 ]
 
 { #category : #style }


### PR DESCRIPTION
Add TLCurrentConnector and use it for some tests.

Fixes #88