### PR TITLE
Adding new test method: testCopyAsSimpleStrategy

### DIFF
--- a/src/Telescope-Core-Tests/TLNodeCreationStrategyTest.class.st
+++ b/src/Telescope-Core-Tests/TLNodeCreationStrategyTest.class.st
@@ -29,6 +29,20 @@ TLNodeCreationStrategyTest >> testCompositeWithLayout [
 ]
 
 { #category : #tests }
+TLNodeCreationStrategyTest >> testCopyAsSimpleStrategy [
+	| aTLNodeCreationStrategy |
+	aTLNodeCreationStrategy := strategy copyAsSimpleStrategy.
+	self
+		assert: aTLNodeCreationStrategy class
+		equals: TLNodeCreationStrategy.
+	self assert: aTLNodeCreationStrategy childrenStrategy isNil.
+	self assert: aTLNodeCreationStrategy compositeProperty isNil.
+	self assert: aTLNodeCreationStrategy childrenSortingStrategy isNil.
+	self assert: aTLNodeCreationStrategy compositeChildrenLayout isNil.
+	self assert: aTLNodeCreationStrategy nodeStyle isNil
+]
+
+{ #category : #tests }
 TLNodeCreationStrategyTest >> testStrategyDefiningStyleForNode [
 	| node |
 	strategy nodeStyle: #myStyle.


### PR DESCRIPTION
I submit this pull request to suggest a new test method `TLNodeCreationStrategyTest>>#testCopyAsSimpleStrategy`.

We noticed that #copyAsSimpleStrategy is never executed by any of the tests in TLCompositeNodeTest. Since this method contains technical debt it is best to guard against future evolutions which may break assumptions made by clients.

Note that these suggestions are adapted from a test amplification tool called SmallAmp (https://github.com/mabdi/small-amp). SmallAmp executes existing tests, sees which parts of the class under test are not covered and then suggests improvements on the test methods.

I hope you will accept this pull request. It would illustrate that SmallAmp makes relevant suggestions.

Mehrdad Abdi.
