### PR TITLE
feat: add a way to show progress of interaction on many node

### DIFF
--- a/src/Telescope-Core/TLBatchCustomAction.class.st
+++ b/src/Telescope-Core/TLBatchCustomAction.class.st
@@ -1,3 +1,6 @@
+"
+I run one or more command on a batch of node. I color each node. After computation on a node, I restore this node's origin color and ask to send result to client.
+"
 Class {
 	#name : #TLBatchCustomAction,
 	#superclass : #Object,

--- a/src/Telescope-Core/TLBatchCustomAction.class.st
+++ b/src/Telescope-Core/TLBatchCustomAction.class.st
@@ -1,0 +1,58 @@
+Class {
+	#name : #TLBatchCustomAction,
+	#superclass : #Object,
+	#instVars : [
+		'block',
+		'drawablesGetter',
+		'aVisualization'
+	],
+	#category : #'Telescope-Core-Utils'
+}
+
+{ #category : #'instance creation' }
+TLBatchCustomAction class >> on: aNodesGetterBlock block: aComputeBlock [
+	^ self new
+		block: aComputeBlock;
+		drawablesGetter: aNodesGetterBlock;
+		yourself
+]
+
+{ #category : #accessing }
+TLBatchCustomAction >> actionOn: aTLDrawable [
+	| drawables highlightStyle generator |
+	generator := aTLDrawable visualization generator.
+	drawables := self drawablesGetter cull: aTLDrawable.
+	highlightStyle := TLStyleCustomizationAction
+		custom: [ :style | 
+			style
+				borderColor: Color red lighter;
+				color: Color red lighter ].
+	drawables
+		do: [ :eachDrawable | highlightStyle regularActionOn: eachDrawable ].
+	generator removeAllCommands.
+	drawables
+		do: [ :eachDrawable | 
+			self block cull: eachDrawable.
+			highlightStyle reverseActionOn: eachDrawable.
+			generator removeAllCommands ]
+]
+
+{ #category : #accessing }
+TLBatchCustomAction >> block [
+	^ block
+]
+
+{ #category : #accessing }
+TLBatchCustomAction >> block: anObject [
+	block := anObject
+]
+
+{ #category : #accessing }
+TLBatchCustomAction >> drawablesGetter [
+	^ drawablesGetter
+]
+
+{ #category : #accessing }
+TLBatchCustomAction >> drawablesGetter: anObject [
+	drawablesGetter := anObject
+]


### PR DESCRIPTION
If interaction run heavy computation on many node, you can use TLBatchCommand to apply computation node by node with a visual progression for user.